### PR TITLE
support class based api

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ then GraphQL::Field resolves `full_name` by decorated Author objects.
 ### Decorate only specific fields
 
 If you want to decorate only specific fields ActiveDecorater::GraphQL provides options to control decoration default and field decoration.
+Class-based API does not support decorate option.
 
 - Control decoration defaults (config/initializers/active_decorator-graphql.rb)
 

--- a/lib/active_decorator/graphql.rb
+++ b/lib/active_decorator/graphql.rb
@@ -13,7 +13,13 @@ module GraphQL
 
     alias resolve_org resolve
     def resolve(object, arguments, context)
-      ::ActiveDecorator::Decorator.instance.decorate(object) if need_decorate?
+      if need_decorate?
+        if object.respond_to?(:object)
+          ::ActiveDecorator::Decorator.instance.decorate(object.object)
+        else
+          ::ActiveDecorator::Decorator.instance.decorate(object)
+        end
+      end
       resolve_org(object, arguments, context)
     end
 

--- a/spec/active_decorator/graphql_spec.rb
+++ b/spec/active_decorator/graphql_spec.rb
@@ -25,78 +25,39 @@ RSpec.describe ActiveDecorator::GraphQL do
       end
     end
 
-    module Types; end
+    describe "define base" do
+      module Types; end
 
-    Types::TestModelType = GraphQL::ObjectType.define do
-      name "TestModel"
-      field :decoration_method, !types.String
-      field :decoration_method_with_decorate_true, !types.String, decorate: true
-      field :decoration_method_with_decorate_false, !types.String, decorate: false
-    end
-
-    Types::QueryType = GraphQL::ObjectType.define do
-      name "Query"
-
-      field :test_model, Types::TestModelType do
-        resolve ->(_, _, _) { TestModel.new }
+      Types::TestModelType = GraphQL::ObjectType.define do
+        name "TestModel"
+        field :decoration_method, !types.String
+        field :decoration_method_with_decorate_true, !types.String, decorate: true
+        field :decoration_method_with_decorate_false, !types.String, decorate: false
       end
-    end
 
-    TestSchema = GraphQL::Schema.define do
-      query(Types::QueryType)
-    end
+      Types::QueryType = GraphQL::ObjectType.define do
+        name "Query"
 
-    specify do
-      query = "{ test_model { decoration_method } }"
+        field :test_model, Types::TestModelType do
+          resolve ->(_, _, _) {
+            TestModel.new }
+        end
+      end
 
-      result = TestSchema.execute(
-        query,
-        variables: {},
-        context:   {},
-      )
-
-      expect(result["data"]["test_model"]["decoration_method"]).to eq("decoration_method")
-    end
-
-    specify do
-      query = "{ test_model { decoration_method_with_decorate_true } }"
-
-      result = TestSchema.execute(
-        query,
-        variables: {},
-        context:   {},
-      )
-
-      expect(result["data"]["test_model"]["decoration_method_with_decorate_true"]).to eq("decoration_method_with_decorate_true")
-    end
-
-    specify do
-      query = "{ test_model { decoration_method_with_decorate_false } }"
-
-      expect {
-        TestSchema.execute(
-          query,
-          variables: {},
-          context:   {},
-        )
-      }.to raise_error(NoMethodError)
-    end
-
-    context "set ActiveDecorator::GraphQL::Config.decorate=false" do
-      before do
-        ActiveDecorator::GraphQL::Config.decorate = false
+      TestSchema = GraphQL::Schema.define do
+        query(Types::QueryType)
       end
 
       specify do
         query = "{ test_model { decoration_method } }"
 
-        expect {
-          TestSchema.execute(
-            query,
-            variables: {},
-            context:   {},
-          )
-        }.to raise_error(NoMethodError)
+        result = TestSchema.execute(
+          query,
+          variables: {},
+          context:   {},
+        )
+
+        expect(result["data"]["test_model"]["decoration_method"]).to eq("decoration_method")
       end
 
       specify do
@@ -121,6 +82,96 @@ RSpec.describe ActiveDecorator::GraphQL do
             context:   {},
           )
         }.to raise_error(NoMethodError)
+      end
+
+      context "set ActiveDecorator::GraphQL::Config.decorate=false" do
+        before do
+          ActiveDecorator::GraphQL::Config.decorate = false
+        end
+
+        specify do
+          query = "{ test_model { decoration_method } }"
+
+          expect {
+            TestSchema.execute(
+              query,
+              variables: {},
+              context:   {},
+            )
+          }.to raise_error(NoMethodError)
+        end
+
+        specify do
+          query = "{ test_model { decoration_method_with_decorate_true } }"
+
+          result = TestSchema.execute(
+            query,
+            variables: {},
+            context:   {},
+          )
+
+          expect(result["data"]["test_model"]["decoration_method_with_decorate_true"]).to eq("decoration_method_with_decorate_true")
+        end
+
+        specify do
+          query = "{ test_model { decoration_method_with_decorate_false } }"
+
+          expect {
+            TestSchema.execute(
+              query,
+              variables: {},
+              context:   {},
+            )
+          }.to raise_error(NoMethodError)
+        end
+      end
+    end
+
+    describe 'class base' do
+      class Types::BaseObject < GraphQL::Schema::Object; end
+
+      class Types::TestModelTypeClassBase < Types::BaseObject
+        field :decoration_method, String, null: false
+        field :decoration_method_with_decorate_true, String, null: false
+        field :decoration_method_with_decorate_false, String, null: false
+      end
+
+      class Types::QueryTypeClassBase < Types::BaseObject
+        field :test_model, Types::TestModelTypeClassBase, null: false, resolve: ->(_, _, _) { TestModel.new }
+      end
+
+      class TestSchemaClassBase < GraphQL::Schema
+        query(Types::QueryTypeClassBase)
+      end
+
+      specify do
+        query = "{ testModel { decorationMethod } }"
+
+        result = TestSchemaClassBase.execute(
+          query,
+          variables: {},
+          context:   {},
+        )
+
+        expect(result["data"]["testModel"]["decorationMethod"]).to eq("decoration_method")
+      end
+
+      context "set ActiveDecorator::GraphQL::Config.decorate=false" do
+        before do
+          ActiveDecorator::GraphQL::Config.decorate = false
+        end
+
+        specify do
+          query = "{ testModel { decorationMethod } }"
+
+          expect {
+            TestSchemaClassBase.execute(
+              query,
+              variables: {},
+              context:   {},
+            )
+          }.to raise_error(RuntimeError)
+        end
       end
     end
   end

--- a/spec/active_decorator/graphql_spec.rb
+++ b/spec/active_decorator/graphql_spec.rb
@@ -144,6 +144,10 @@ RSpec.describe ActiveDecorator::GraphQL do
         query(Types::QueryTypeClassBase)
       end
 
+      before do
+        ActiveDecorator::GraphQL::Config.decorate = true
+      end
+
       specify do
         query = "{ testModel { decorationMethod } }"
 


### PR DESCRIPTION
@hshimoyama 
thanks for your wonderful gems!

If the class-based API is used, the object argument passed to the resolve method is an instance of derived class from `GraphQL::Schema::Object` .
so the decorate target is `object.object` instead of `object` variable.
also, when using class based api, the method of extending field option was not found, so `decorate` option is not supported
